### PR TITLE
ALS-1862 Typo and get credential with API key return empty credential fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import okhttp3.OkHttpClient
 You can create an AuthHelper and use it with the AWS Kotlin SDK:
 
 ```
-// Create a credentail provider using Identity Pool Id with AuthHelper
+// Create a credential provider using Identity Pool Id with AuthHelper
 private suspend fun exampleCognitoLogin() {
     var authHelper = AuthHelper(applicationContext)
     var locationCredentialsProvider : LocationCredentialsProvider = authHelper.authenticateWithCognitoIdentityPool("MY-COGNITO-IDENTITY-POOL-ID")
@@ -43,7 +43,7 @@ private suspend fun exampleCognitoLogin() {
 
 OR
 
-// Create a credentail provider using custom credential provider with AuthHelper
+// Create a credential provider using custom credential provider with AuthHelper
 private suspend fun exampleCustomCredentialLogin() {
     var authHelper = AuthHelper(applicationContext)
     var locationCredentialsProvider : LocationCredentialsProvider = authHelper.authenticateWithCredentialsProvider("MY-AWS-REGION", MY-CUSTOM-CREDENTIAL-PROVIDER)
@@ -52,11 +52,11 @@ private suspend fun exampleCustomCredentialLogin() {
 
 OR
 
-// Create a credentail provider using Api key with AuthHelper
+// Create a credential provider using Api key with AuthHelper
 private suspend fun exampleApiKeyLogin() {
     var authHelper = AuthHelper(applicationContext)
     var locationCredentialsProvider : LocationCredentialsProvider = authHelper.authenticateWithApiKey("MY-API-KEY", "MY-AWS-REGION")
-    var locationClient = locationCredentialsProvider.getLocationClient()
+    var locationClient = locationCredentialsProvider?.getLocationClient()
 }
 ```
 You can use the LocationCredentialsProvider to load the maplibre map. Here is an example of that:

--- a/library/src/main/java/software/amazon/location/auth/AwsSignerInterceptor.kt
+++ b/library/src/main/java/software/amazon/location/auth/AwsSignerInterceptor.kt
@@ -66,9 +66,9 @@ class AwsSignerInterceptor(
                     credentialsProvider.verifyAndRefreshCredentials()
                 }
             }
-            val accessKeyId = credentialsProvider.getCredentialsProvider()?.accessKeyId
-            val secretKey = credentialsProvider.getCredentialsProvider()?.secretKey
-            val sessionToken = credentialsProvider.getCredentialsProvider()?.sessionToken
+            val accessKeyId = credentialsProvider.getCredentialsProvider().accessKeyId
+            val secretKey = credentialsProvider.getCredentialsProvider().secretKey
+            val sessionToken = credentialsProvider.getCredentialsProvider().sessionToken
             if (!accessKeyId.isNullOrEmpty() && !secretKey.isNullOrEmpty() && !sessionToken.isNullOrEmpty() && region.isNotEmpty()) {
                 val dateMilli = Date().time
                 val host = extractHostHeader(originalRequest.url.toString())

--- a/library/src/main/java/software/amazon/location/auth/utils/AwsAuthorizationHeaderHelper.kt
+++ b/library/src/main/java/software/amazon/location/auth/utils/AwsAuthorizationHeaderHelper.kt
@@ -10,7 +10,7 @@ import software.amazon.location.auth.utils.Constants.SIGNING_ALGORITHM
 /**
  * Sign the request with the aws authorization header
  */
-fun Request.awsAuthorizationHeader(
+internal fun Request.awsAuthorizationHeader(
     accessKeyId: String,
     accessKey: String,
     region: String,
@@ -30,7 +30,7 @@ fun Request.awsAuthorizationHeader(
         time
     )}"
 
-fun Request.signature(
+internal fun Request.signature(
     accessKey: String,
     region: String,
     service: String,
@@ -46,7 +46,7 @@ fun Request.signature(
         stringToSign(region, service, time)
     ).toHexString()
 
-fun Request.stringToSign(region: String, service: String, time: String) =
+internal fun Request.stringToSign(region: String, service: String, time: String) =
     """
     |$SIGNING_ALGORITHM
     |${time}
@@ -54,7 +54,7 @@ fun Request.stringToSign(region: String, service: String, time: String) =
     |${hash(canonicalRequest())}
     """.trimMargin("|")
 
-fun Request.canonicalRequest() =
+internal fun Request.canonicalRequest() =
     """
     |$method
     |${canonicalUri()}

--- a/library/src/main/java/software/amazon/location/auth/utils/CryptoUtils.kt
+++ b/library/src/main/java/software/amazon/location/auth/utils/CryptoUtils.kt
@@ -9,11 +9,11 @@ import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import software.amazon.location.auth.utils.Constants.DEFAULT_ENCODING
 
-const val HASHING_ALGORITHM = "SHA-256"
-const val MAC_ALGORITHM = "HmacSHA256"
-const val ENCODED_CHARACTER_REGEX = "%[0-9A-Fa-f]{2}"
+internal const val HASHING_ALGORITHM = "SHA-256"
+internal const val MAC_ALGORITHM = "HmacSHA256"
+internal const val ENCODED_CHARACTER_REGEX = "%[0-9A-Fa-f]{2}"
 
-fun hash(value: String): String {
+internal fun hash(value: String): String {
     val bytes = value.toByteArray()
     val md = MessageDigest.getInstance(HASHING_ALGORITHM)
     val digest = md.digest(bytes)
@@ -21,7 +21,7 @@ fun hash(value: String): String {
 }
 
 @Throws(Exception::class)
-fun hmacSha256(key: ByteArray, data: String): ByteArray {
+internal fun hmacSha256(key: ByteArray, data: String): ByteArray {
     val sha256Hmac = Mac.getInstance(MAC_ALGORITHM)
     val secretKey = SecretKeySpec(key, MAC_ALGORITHM)
     sha256Hmac.init(secretKey)
@@ -30,10 +30,10 @@ fun hmacSha256(key: ByteArray, data: String): ByteArray {
 }
 
 @Throws(Exception::class)
-fun hmacSha256(key: String, data: String) =
+internal fun hmacSha256(key: String, data: String) =
     hmacSha256(key.toByteArray(Charset.forName("utf-8")), data)
 
-fun ByteArray.toHexString(): String{
+internal fun ByteArray.toHexString(): String{
     return joinToString("") { "%02x".format(it) }
 }
 


### PR DESCRIPTION
fix: Typo error fixed in README.md
fix: Api key get credential returns empty credential fix
fix: CryptoUtils.kt and AwsAuthorizationHeaderHelper.kt files method revert back to internal